### PR TITLE
Introduce LK_INIT_CONFIG for lock initialization and add isolated lock_manager unit-test harness

### DIFF
--- a/src/transaction/lock_manager.c
+++ b/src/transaction/lock_manager.c
@@ -429,6 +429,7 @@ static const int SIZEOF_LK_ACQOBJ_LOCK = sizeof (LK_ACQOBJ_LOCK);
 /* minimum # of locks that are required */
 /* TODO : change const */
 #define LK_MIN_OBJECT_LOCKS  (MAX_NTRANS * 300)
+#define LK_INITIAL_OBJECT_LOCK_TABLE_SIZE 10000
 
 /* the ratio in the number of lock entries for each entry type */
 static const float LK_RES_RATIO = 0.1f;
@@ -490,8 +491,10 @@ static void lock_initialize_resource (LK_RES * res_ptr);
 static void lock_initialize_resource_as_allocated (LK_RES * res_ptr, LOCK lock);
 static unsigned int lock_get_hash_value (const OID * oid, int htsize);
 static int lock_initialize_tran_lock_table (void);
-static void lock_initialize_object_hash_table (void);
-static int lock_initialize_object_lock_entry_list (void);
+static void lock_initialize_default_config_internal (LK_INIT_CONFIG *config);
+static void lock_sanitize_init_config (LK_INIT_CONFIG *config);
+static void lock_initialize_object_hash_table (const LK_INIT_CONFIG *config);
+static int lock_initialize_object_lock_entry_list (const LK_INIT_CONFIG *config);
 static int lock_initialize_deadlock_detection (void);
 static int lock_remove_resource (THREAD_ENTRY * thread_p, LK_RES * res_ptr);
 static void lock_finalize_tran_lock_table (void);
@@ -1116,15 +1119,52 @@ lock_initialize_tran_lock_table (void)
  * Note:This function initializes an object lock hash table.
  */
 static void
-lock_initialize_object_hash_table (void)
+lock_initialize_default_config_internal (LK_INIT_CONFIG * config)
 {
-#define LK_INITIAL_OBJECT_LOCK_TABLE_SIZE       10000
+  config->initial_object_locks = LK_INITIAL_OBJECT_LOCK_TABLE_SIZE;
+  config->object_res_block_count = 2;
+  config->object_entry_block_count = 1;
+  config->start_deadlock_detector = true;
+}
+#endif /* SERVER_MODE */
 
-  lk_Gl.max_obj_locks = LK_INITIAL_OBJECT_LOCK_TABLE_SIZE;
+#if defined(SERVER_MODE)
+static void
+lock_sanitize_init_config (LK_INIT_CONFIG * config)
+{
+  if (config->initial_object_locks <= 0)
+    {
+      config->initial_object_locks = LK_INITIAL_OBJECT_LOCK_TABLE_SIZE;
+    }
+
+  if (config->object_res_block_count <= 0)
+    {
+      config->object_res_block_count = 2;
+    }
+
+  if (config->object_entry_block_count <= 0)
+    {
+      config->object_entry_block_count = 1;
+    }
+}
+#endif /* SERVER_MODE */
+
+#if defined(SERVER_MODE)
+/*
+ * lock_initialize_object_hash_table - Initializes the object lock hash table
+ *
+ * return: error code
+ *
+ * Note:This function initializes an object lock hash table.
+ */
+static void
+lock_initialize_object_hash_table (const LK_INIT_CONFIG * config)
+{
+  lk_Gl.max_obj_locks = config->initial_object_locks;
 
   const int obj_hash_size = MAX (lk_Gl.max_obj_locks, LK_MIN_OBJECT_LOCKS);
 
-  const int block_count = 2;
+  const int block_count = config->object_res_block_count;
   const int block_size = (int) MAX ((lk_Gl.max_obj_locks * LK_RES_RATIO) / block_count, 1);
   lk_Obj_lock_res_desc.max_alloc_cnt = prm_get_integer_value (PRM_ID_LK_ESCALATION_AT);
 
@@ -1147,12 +1187,12 @@ lock_initialize_object_hash_table (void)
  *     2. a list of freed object lock entries.
  */
 static int
-lock_initialize_object_lock_entry_list (void)
+lock_initialize_object_lock_entry_list (const LK_INIT_CONFIG * config)
 {
   int block_count, block_size, ret;
 
   /* initialize the entry freelist */
-  block_count = 1;
+  block_count = config->object_entry_block_count;
   block_size = (int) MAX ((lk_Gl.max_obj_locks * LK_ENTRY_RATIO), 1);
   obj_lock_entry_desc.max_alloc_cnt = prm_get_integer_value (PRM_ID_LK_ESCALATION_AT);
 
@@ -5621,23 +5661,43 @@ lock_dump_resource (THREAD_ENTRY * thread_p, FILE * outfp, LK_RES * res_ptr)
  *
  * Note:Initialize the lock manager memory structures.
  */
+void
+lock_initialize_default_config (LK_INIT_CONFIG * config)
+{
+#if defined (SERVER_MODE)
+  assert (config != NULL);
+
+  lock_initialize_default_config_internal (config);
+#else /* defined (SERVER_MODE) */
+  (void) config;
+#endif /* defined (SERVER_MODE) */
+}
+
 int
-lock_initialize (void)
+lock_initialize_with_config (const LK_INIT_CONFIG * config)
 {
 #if !defined (SERVER_MODE)
   lk_Standalone_has_xlock = false;
   return NO_ERROR;
-#else /* !SERVER_MODE */
+#else /* !defined (SERVER_MODE) */
   const char *env_value;
   int error_code = NO_ERROR;
+  LK_INIT_CONFIG local_config;
+
+  lock_initialize_default_config_internal (&local_config);
+  if (config != NULL)
+    {
+      local_config = *config;
+    }
+  lock_sanitize_init_config (&local_config);
 
   error_code = lock_initialize_tran_lock_table ();
   if (error_code != NO_ERROR)
     {
       goto error;
     }
-  lock_initialize_object_hash_table ();
-  error_code = lock_initialize_object_lock_entry_list ();
+  lock_initialize_object_hash_table (&local_config);
+  error_code = lock_initialize_object_lock_entry_list (&local_config);
   if (error_code != NO_ERROR)
     {
       goto error;
@@ -5678,7 +5738,10 @@ lock_initialize (void)
     }
 #endif /* LK_DUMP */
 
-  lock_deadlock_detect_daemon_init ();
+  if (local_config.start_deadlock_detector)
+    {
+      lock_deadlock_detect_daemon_init ();
+    }
 
   return error_code;
 
@@ -5686,6 +5749,12 @@ error:
   (void) lock_finalize ();
   return error_code;
 #endif /* !SERVER_MODE */
+}
+
+int
+lock_initialize (void)
+{
+  return lock_initialize_with_config (NULL);
 }
 
 #if defined(SERVER_MODE)
@@ -5825,6 +5894,7 @@ void
 lock_deadlock_detect_daemon_destroy ()
 {
   cubthread::get_manager ()->destroy_daemon (lock_Deadlock_detect_daemon);
+  lock_Deadlock_detect_daemon = NULL;
 }
 #endif /* SERVER_MODE */
 
@@ -5877,7 +5947,10 @@ lock_finalize (void)
   lk_Gl.m_obj_hash_table.destroy ();
   lf_freelist_destroy (&lk_Gl.obj_free_entry_list);
 
-  lock_deadlock_detect_daemon_destroy ();
+  if (lock_Deadlock_detect_daemon != NULL)
+    {
+      lock_deadlock_detect_daemon_destroy ();
+    }
 #endif /* !SERVER_MODE */
 }
 

--- a/src/transaction/lock_manager.h
+++ b/src/transaction/lock_manager.h
@@ -72,6 +72,15 @@ typedef enum
   KEY_LOCK_ESCALATED = 2
 } KEY_LOCK_ESCALATION;
 
+typedef struct lk_init_config LK_INIT_CONFIG;
+struct lk_init_config
+{
+  int initial_object_locks;
+  int object_res_block_count;
+  int object_entry_block_count;
+  bool start_deadlock_detector;
+};
+
 /*****************************/
 /* Lock Heap Entry Structure */
 /*****************************/
@@ -194,6 +203,8 @@ struct lk_res
 #if defined(SERVER_MODE)
 extern void lock_remove_all_inst_locks (THREAD_ENTRY * thread_p, int tran_index, const OID * class_oid, LOCK lock);
 #endif /* SERVER_MODE */
+extern void lock_initialize_default_config (LK_INIT_CONFIG *config);
+extern int lock_initialize_with_config (const LK_INIT_CONFIG *config);
 extern int lock_initialize (void);
 extern void lock_finalize (void);
 extern int lock_hold_object_instant (THREAD_ENTRY * thread_p, const OID * oid, const OID * class_oid, LOCK lock);

--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -38,6 +38,7 @@ option (UNIT_TEST_RESOURCE_TRACKER "Unit testing: resource tracker")
 option (UNIT_TEST_MONITOR "Unit testing: monitor")
 option (UNIT_TEST_LOADDB "Unit testing: loaddb module")
 option (UNIT_TEST_MEMORY_MONITOR "Unit testing: memory monitor")
+option (UNIT_TEST_LOCK_MANAGER "Unit testing: lock manager")
 
 message("  unit_tests/...")
 
@@ -102,6 +103,11 @@ if (UNIT_TESTS OR UNIT_TEST_MONITOR)
   message("    monitor")
   add_subdirectory(monitor)
 endif(UNIT_TESTS OR UNIT_TEST_MONITOR)
+
+if (UNIT_TEST_LOCK_MANAGER)
+  message("    lock_manager")
+  add_subdirectory(lock_manager)
+endif(UNIT_TEST_LOCK_MANAGER)
 
 #[[
 TODO compilation fails

--- a/unit_tests/lock_manager/CMakeLists.txt
+++ b/unit_tests/lock_manager/CMakeLists.txt
@@ -1,0 +1,52 @@
+#
+#  Copyright 2008 Search Solution Corporation
+#  Copyright 2016 CUBRID Corporation
+# 
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+# 
+#       http://www.apache.org/licenses/LICENSE-2.0
+# 
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+# 
+#
+
+set (TEST_LOCK_MANAGER_SOURCES
+  test_main.cpp
+  test_lock_manager_scenarios.cpp
+  test_lock_manager_mock_runtime.cpp
+  test_lock_manager_functional.cpp
+  test_lock_manager_benchmark.cpp
+  )
+
+set (TEST_LOCK_MANAGER_HEADERS
+  test_lock_manager_scenarios.hpp
+  test_lock_manager_mock_runtime.hpp
+  )
+
+SET_SOURCE_FILES_PROPERTIES (
+  ${TEST_LOCK_MANAGER_SOURCES}
+  PROPERTIES LANGUAGE CXX
+  )
+
+add_executable (test_lock_manager
+  ${TEST_LOCK_MANAGER_SOURCES}
+  ${TEST_LOCK_MANAGER_HEADERS}
+  )
+
+target_compile_definitions (test_lock_manager PRIVATE
+  ${COMMON_DEFS}
+  )
+
+target_include_directories (test_lock_manager PRIVATE
+  ${TEST_INCLUDES}
+  )
+
+target_link_libraries (test_lock_manager LINK_PRIVATE
+  test_common
+  )

--- a/unit_tests/lock_manager/README.md
+++ b/unit_tests/lock_manager/README.md
@@ -1,0 +1,368 @@
+# lock_manager Performance Test and Isolated Loading Design Notes
+
+This document summarizes a recommended direction for loading the lock manager implemented in
+`src/transaction/lock_manager.c` and `src/transaction/lock_manager.h` more independently in the
+`unit_tests/` style, and for measuring its performance without coupling it to real
+DB/storage/query module load.
+
+## Goals
+
+- It should be possible to generate large numbers of lock resources using mock `OID` values.
+- The lock manager should be measured in isolation from the real load of surrounding modules such as storage,
+  locator, query, and boot.
+- Like other `unit_tests/` modules, it should be runnable through an explicit test binary (`test_lock_manager`).
+- Functional verification and performance measurement should be separated, while sharing the same fixture and
+  scenario definitions.
+
+## Why a dedicated harness is needed
+
+At the moment, `lock_manager.c` is difficult to test in isolation by simply calling a few functions directly,
+because it has the following characteristics:
+
+- It is tightly coupled to `THREAD_ENTRY`, the transaction table, the deadlock/wait-for graph,
+  and thread suspend/resume flows.
+- It indirectly references global state from the boot/log/query/monitor layers.
+- Its internal state is built around a global lock table, daemon threads, and hash buckets, so fixture setup is heavy.
+- From a performance perspective, what we usually want to observe is lock hash collisions, wait queue length,
+  lock conversion, and deadlock detection overhead, all of which can be reproduced independently of DB page I/O.
+
+Because of that, it is better to build a lock-manager-specific seam and load the module through
+`unit_tests/lock_manager/` than to start by booting the entire server and then stressing the lock manager.
+
+At the current code stage, a good first step is an **initialization seam** based on `LK_INIT_CONFIG`,
+`lock_initialize_default_config()`, and `lock_initialize_with_config()`, so object lock table sizing,
+block partitioning, and daemon startup can be controlled externally.
+
+## Recommended architecture
+
+### 1. Add a lock-manager-specific runtime seam
+
+It is recommended to gather the external dependencies that `lock_manager.c` accesses directly into one small
+structure. The core idea is to separate the locking algorithm from server runtime services.
+
+Example:
+
+```c
+/* conceptual example */
+typedef struct lk_runtime lk_runtime;
+struct lk_runtime
+{
+  THREAD_ENTRY *(*find_thread_by_tran_index) (int tran_index);
+  int (*get_current_tran_index) (THREAD_ENTRY *thread_p);
+  void (*suspend_thread) (THREAD_ENTRY *thread_p);
+  void (*resume_thread) (THREAD_ENTRY *thread_p, int wait_state);
+  INT64 (*get_clock_msec) (void);
+  void *(*alloc_fn) (size_t size);
+  void (*free_fn) (void *ptr);
+  void (*event_log_fn) (const char *msg);
+};
+```
+
+The production server would provide a `server_runtime` wrapper around the existing implementation,
+while unit tests would provide a `mock_runtime` to control:
+
+- transaction-index-to-thread mapping
+- suspend/resume events
+- time progression
+- memory instrumentation
+- wakeup ordering observation for deadlock victim selection
+
+### 2. Split the initialization path into two layers
+
+Keep the current `lock_initialize()` / `lock_finalize()` entry points, but add test-oriented initialization APIs such as:
+
+```c
+void lock_initialize_default_config (LK_INIT_CONFIG *config);
+int lock_initialize_with_config (const LK_INIT_CONFIG *config);
+```
+
+`LK_INIT_CONFIG` should provide at least the following controls:
+
+- hash bucket sizing
+- resource freelist preallocation sizing
+- entry freelist preallocation sizing
+- deadlock detector on/off
+- detector execution interval
+- lock escalation threshold override
+
+This allows unit tests and benchmarks to exercise the same code path without being pinned to server defaults.
+
+### 3. Let the test module own mock OID generation
+
+Even without the real object module, lock resource keys can be created as long as the `OID` values are filled in
+consistently. Recommended rules:
+
+- Use a fixed `volid` as a workload namespace, for example `1`.
+- Use `pageid` to control hot/cold sets.
+- Use `slotid` to control row fan-out.
+- Use a different `pageid` range for class OIDs than for instance OIDs to make collision analysis easier.
+
+Example:
+
+```c
+static OID
+make_mock_oid (int pageid, short slotid)
+{
+  OID oid;
+  oid.volid = 1;
+  oid.pageid = pageid;
+  oid.slotid = slotid;
+  return oid;
+}
+```
+
+With this approach, the following cases can be reproduced without descending into storage/object/locator:
+
+- hotspot contention on the same row
+- many row locks under the same class
+- mixed class-lock and instance-lock behavior
+- biased hash bucket collisions
+
+## Workload scenarios to measure first
+
+The scenarios below are useful for observing the lock manager structure itself, independent of full DB engine load.
+
+### A. Single hot-row contention
+
+- `N` workers repeatedly request `X_LOCK` on the same `(class_oid, oid)`
+- Purpose:
+  - acquire latency growth as waiter queue length increases
+  - suspend/resume cost
+  - lock entry reuse efficiency
+- Metrics:
+  - throughput (ops/sec)
+  - p50/p95/p99 acquire latency
+  - average queue depth
+  - confirmation that no timeout/deadlock occurs in the intended scenario
+
+### B. Hot class + cold rows mix
+
+- 10% class-level `IX`/`X`
+- 90% instance-level `S`/`X` on different rows within the same class
+- Purpose:
+  - conflict cost between class locks and instance locks
+  - update cost of total holder/waiter modes
+  - behavior near the lock escalation threshold
+
+### C. Lock-conversion-heavy workload
+
+- The same transaction repeatedly performs `S -> X`, `IS -> IX`, or `IX -> X` conversion
+- Purpose:
+  - conversion cost inside the holder list
+  - fairness when new waiters arrive while a conversion is waiting
+
+### D. Deadlock detector stress
+
+- Two or more worker groups lock rows in cross order to intentionally create cycles
+- Purpose:
+  - wait-for graph update cost
+  - scan cost per detector run
+  - recovery time after victim selection
+- Variants:
+  - 2-cycle, 3-cycle, long chain + single back edge
+
+### E. Hash collision stress
+
+- Intentionally map mock OIDs to the same bucket
+- Purpose:
+  - performance degradation as resource hash chains grow
+  - bucket mutex contention measurement
+- Required support:
+  - hash size should be overridable during test initialization
+
+### F. Many transactions / low contention
+
+- There are many workers, but each uses a distinct OID set
+- Purpose:
+  - baseline acquire/release cost when contention is minimal
+  - separation of entry allocation/free cost and transaction-list linking cost
+
+### G. Escalation threshold sweep
+
+- Gradually increase the number of row locks under a single class and sweep the threshold
+- Purpose:
+  - performance difference before and after row-to-class escalation
+  - sensitivity of the threshold value
+
+## Metric design
+
+Performance testing should not rely only on total execution time; it also needs counters aligned with the internal
+structure of the lock manager. Recommended counters:
+
+- total acquire attempts / successes / timeouts / deadlock victims
+- immediate grant ratio
+- conversion success count
+- maximum resource hash bucket chain length
+- average and maximum holder/waiter lengths
+- deadlock detector run count / total elapsed time
+- suspend/resume count
+- freelist hit/miss count
+
+If possible, internal instrumentation hooks such as `#if defined (UNIT_TEST_LOCK_MANAGER_INTERNALS)` should be used,
+and disabled in production builds.
+
+## Recommended file layout for `unit_tests/lock_manager`
+
+```text
+unit_tests/lock_manager/
+├── CMakeLists.txt
+├── test_main.cpp
+├── test_lock_manager_functional.cpp
+├── test_lock_manager_benchmark.cpp
+├── test_lock_manager_mock_runtime.hpp
+├── test_lock_manager_mock_runtime.cpp
+├── test_lock_manager_scenarios.hpp
+└── test_lock_manager_scenarios.cpp
+```
+
+### Responsibility split
+
+- `test_lock_manager_functional.cpp`
+  - wait queue ordering
+  - conversion correctness
+  - timeout/deadlock recovery correctness
+- `test_lock_manager_benchmark.cpp`
+  - run scenarios A-G above
+  - sweep thread count / hash size / hotspot ratio
+- `test_lock_manager_mock_runtime.*`
+  - mock thread registry
+  - mock suspend/resume
+  - fake clock / event hooks
+- `test_lock_manager_scenarios.*`
+  - generate mock OID sets
+  - define workload scripts
+
+## Current runner usage
+
+The current `test_lock_manager` binary can already list and execute deterministic scenario plans.
+It does not yet drive the production lock manager directly, but it does let you run the planned workloads,
+inspect operation mixes, and validate that mock OID generation and scenario composition match expectations.
+
+Examples:
+
+```bash
+test_lock_manager --list
+test_lock_manager --scenario hot_row --workers 8 --iterations 1000 --sample 10
+test_lock_manager --scenario deadlock_detector --workers 4 --iterations 20 --sample 12
+test_lock_manager --scenario escalation_sweep --workers 8 --iterations 50 --hotset 16
+```
+
+### How to run each test mode
+
+#### 1. Scenario inspection mode
+
+Use this mode to generate a deterministic mock-OID workload and inspect its composition.
+
+```bash
+test_lock_manager --scenario hot_row --workers 8 --iterations 1000 --sample 10
+```
+
+This prints:
+
+- the scenario name and description
+- worker count / iteration count / hotset size
+- total operation count
+- distinct class count / distinct OID count
+- operation-kind and lock-mode distributions
+- a sample of generated operations
+
+#### 2. Functional test mode
+
+Use this mode to run deterministic checks for a subset of scenarios against the mock runtime.
+
+```bash
+test_lock_manager --functional
+```
+
+The current functional suite validates:
+
+- `hot_row` uses exactly one target OID
+- `lock_conversion` produces conversion events
+- `deadlock_detector` produces at least one deadlock pair in the mock runtime
+- `escalation_sweep` produces escalation candidates
+
+Each passing scenario is printed as a separate `[functional] passed: ...` line.
+
+#### 3. Benchmark mode
+
+Use this mode to run all implemented scenarios repeatedly and print CSV-style performance output.
+
+```bash
+test_lock_manager --benchmark --loops 100
+```
+
+The output columns are:
+
+- `scenario`
+- `loops`
+- `ops`
+- `total_us`
+- `ops_per_sec`
+- `conflicts`
+- `deadlock_pairs`
+- `conversions`
+- `escalation_candidates`
+
+This is useful for comparing relative workload pressure even before the harness is connected to the production lock manager.
+
+## Incremental rollout order
+
+### Step 1: add the seam, no functional change
+
+- Wrap the external dependencies of `lock_manager.c` with small wrapper functions.
+- Keep the default runtime bound to the existing server implementation.
+- Preserve current behavior by making `lock_initialize()` use the default runtime internally.
+
+### Step 2: secure deterministic functional unit tests with a mock runtime
+
+- Start with deterministic 1-thread, 2-thread, and 3-thread scenarios.
+- Control deadlock and timeout behavior using a fake clock so tests stay non-flaky.
+
+### Step 3: add a benchmark binary
+
+- Build `test_lock_manager` only when `UNIT_TEST_LOCK_MANAGER=ON`.
+- Accept runtime arguments such as scenario/thread_count/seconds/hash_size.
+- Print results to stdout in table form, and optionally also export CSV.
+
+### Step 4: separate CI from performance runs
+
+- Only correctness tests should run in CI.
+- Benchmarks should run locally or on dedicated machines.
+- Raw performance numbers should not be used as CI pass/fail criteria; instead, maintain a separate baseline
+  comparison script for regression tracking.
+
+## Implementation cautions
+
+- `lock_manager.c` is large and heavily coupled, so avoid large refactors at the beginning.
+  It is safer to start by wrapping only the external call boundaries.
+- Do not try to mock the full `THREAD_ENTRY` immediately.
+  It is better to design a lightweight fixture around the fields that the lock manager actually reads.
+- Instead of always running the deadlock detector as a real daemon thread in tests,
+  it is better for reproducibility to support an explicit `tick_detector()`-style call.
+- Benchmarks should keep OID generation rules under a fixed seed so runs are comparable.
+
+## Recommended first minimum deliverable
+
+Instead of trying to build a fully standalone lock manager immediately, the following sequence is more realistic:
+
+1. inventory the external dependencies of `lock_manager`
+2. add `lock_initialize_with_config()`
+3. add `unit_tests/lock_manager/test_lock_manager_mock_runtime.*`
+4. implement only scenarios A, D, and E first
+5. add internal counter dumps
+
+Even these five steps are enough to answer practical questions such as:
+
+- How much does increasing hash bucket count improve hotspot-row contention?
+- How do throughput and victim detection time change when the deadlock detector interval is reduced?
+- Which bottleneck appears first: row-level hotspot contention or class-level contention?
+
+## Conclusion
+
+For lock manager performance testing, independently loading `lock_manager` with a mock runtime + mock OID workload is
+far more efficient and analytically useful than trying to reproduce full-DB workloads first.
+
+In one sentence, the recommended direction is this:
+
+> To run `lock_manager` as a dedicated unit-tests-style binary,
+> separate server dependencies through a runtime seam and measure mock-OID-based scenarios A-G first.

--- a/unit_tests/lock_manager/test_lock_manager_benchmark.cpp
+++ b/unit_tests/lock_manager/test_lock_manager_benchmark.cpp
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2008 Search Solution Corporation
+ * Copyright 2016 CUBRID Corporation
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+#include "test_lock_manager_mock_runtime.hpp"
+
+#include <chrono>
+#include <iostream>
+
+namespace test_lock_manager
+{
+  int
+  run_benchmark_suite (int loops)
+  {
+    const scenario_kind scenarios[] = {
+      scenario_kind::hot_row,
+      scenario_kind::hot_class_cold_rows,
+      scenario_kind::lock_conversion,
+      scenario_kind::deadlock_detector,
+      scenario_kind::hash_collision,
+      scenario_kind::low_contention,
+      scenario_kind::escalation_sweep
+    };
+
+    mock_runtime runtime;
+
+    std::cout << "scenario,loops,ops,total_us,ops_per_sec,conflicts,deadlock_pairs,conversions,escalation_candidates" << std::endl;
+
+    for (scenario_kind kind : scenarios)
+      {
+        const scenario_config config { kind, 8, 100, 16, 1 };
+        std::vector<operation> operations = build_operations (config);
+        simulation_stats total { 0, 0, 0, 0, 0, 0, 0 };
+
+        const auto start = std::chrono::steady_clock::now ();
+        for (int loop = 0; loop < loops; loop++)
+          {
+            simulation_stats stats = runtime.simulate (operations);
+            total.acquire_attempts += stats.acquire_attempts;
+            total.acquire_grants += stats.acquire_grants;
+            total.acquire_conflicts += stats.acquire_conflicts;
+            total.conversions += stats.conversions;
+            total.releases += stats.releases;
+            total.deadlock_pairs += stats.deadlock_pairs;
+            total.escalation_candidates += stats.escalation_candidates;
+          }
+        const auto end = std::chrono::steady_clock::now ();
+        const auto total_us = std::chrono::duration_cast<std::chrono::microseconds> (end - start).count ();
+        const double ops_per_sec = total_us > 0 ? (operations.size () * loops * 1000000.0) / total_us : 0.0;
+
+        std::cout << to_string (kind) << ','
+                  << loops << ','
+                  << operations.size () << ','
+                  << total_us << ','
+                  << ops_per_sec << ','
+                  << total.acquire_conflicts << ','
+                  << total.deadlock_pairs << ','
+                  << total.conversions << ','
+                  << total.escalation_candidates
+                  << std::endl;
+      }
+
+    return 0;
+  }
+} // namespace test_lock_manager

--- a/unit_tests/lock_manager/test_lock_manager_functional.cpp
+++ b/unit_tests/lock_manager/test_lock_manager_functional.cpp
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2008 Search Solution Corporation
+ * Copyright 2016 CUBRID Corporation
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+#include "test_lock_manager_mock_runtime.hpp"
+
+#include <iostream>
+#include <stdexcept>
+#include <vector>
+
+namespace test_lock_manager
+{
+  namespace
+  {
+    void
+    require_true (bool condition, const std::string &message)
+    {
+      if (!condition)
+        {
+          throw std::runtime_error (message);
+        }
+    }
+  } // namespace
+
+  int
+  run_functional_suite (void)
+  {
+    const scenario_config configs[] = {
+      { scenario_kind::hot_row, 4, 8, 1, 1 },
+      { scenario_kind::lock_conversion, 4, 6, 4, 1 },
+      { scenario_kind::deadlock_detector, 4, 5, 4, 1 },
+      { scenario_kind::escalation_sweep, 8, 12, 16, 1 }
+    };
+
+    mock_runtime runtime;
+
+    for (const scenario_config &config : configs)
+      {
+        const std::vector<operation> operations = build_operations (config);
+        const scenario_summary summary = summarize (config.kind, operations);
+        const simulation_stats stats = runtime.simulate (operations);
+
+        require_true (!operations.empty (), "scenario generated no operations: " + summary.name);
+        require_true (summary.operation_count == operations.size (), "operation count mismatch: " + summary.name);
+
+        if (config.kind == scenario_kind::hot_row)
+          {
+            require_true (summary.distinct_oid_count == 1, "hot_row should use exactly one target OID");
+          }
+        else if (config.kind == scenario_kind::lock_conversion)
+          {
+            require_true (stats.conversions > 0, "lock_conversion should record conversions");
+          }
+        else if (config.kind == scenario_kind::deadlock_detector)
+          {
+            require_true (stats.deadlock_pairs > 0, "deadlock_detector should observe deadlock pairs");
+          }
+        else if (config.kind == scenario_kind::escalation_sweep)
+          {
+            require_true (stats.escalation_candidates > 0, "escalation_sweep should produce escalation candidates");
+          }
+
+        std::cout << "[functional] passed: " << summary.name << std::endl;
+      }
+
+    return 0;
+  }
+} // namespace test_lock_manager

--- a/unit_tests/lock_manager/test_lock_manager_mock_runtime.cpp
+++ b/unit_tests/lock_manager/test_lock_manager_mock_runtime.cpp
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2008 Search Solution Corporation
+ * Copyright 2016 CUBRID Corporation
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+#include "test_lock_manager_mock_runtime.hpp"
+
+#include <map>
+#include <set>
+#include <sstream>
+#include <vector>
+#include <utility>
+
+namespace test_lock_manager
+{
+  namespace
+  {
+    bool
+    has_path (const std::set<std::pair<int, int>> &edges, int from_txn, int to_txn)
+    {
+      std::set<int> visited;
+      std::vector<int> stack;
+
+      stack.push_back (from_txn);
+      while (!stack.empty ())
+        {
+          const int current = stack.back ();
+          stack.pop_back ();
+
+          if (current == to_txn)
+            {
+              return true;
+            }
+
+          if (visited.insert (current).second == false)
+            {
+              continue;
+            }
+
+          for (const std::pair<int, int> &edge : edges)
+            {
+              if (edge.first == current)
+                {
+                  stack.push_back (edge.second);
+                }
+            }
+        }
+
+      return false;
+    }
+  } // namespace
+
+  mock_runtime::mock_runtime ()
+  {
+  }
+
+  std::string
+  mock_runtime::make_resource_key (const operation &op) const
+  {
+    std::ostringstream out;
+    out << op.class_oid.volid << ':' << op.class_oid.pageid << ':' << op.class_oid.slotid
+        << '/' << op.oid.volid << ':' << op.oid.pageid << ':' << op.oid.slotid;
+    return out.str ();
+  }
+
+  simulation_stats
+  mock_runtime::simulate (const std::vector<operation> &operations)
+  {
+    simulation_stats stats { 0, 0, 0, 0, 0, 0, 0 };
+    std::map<std::string, int> owners;
+    std::map<int, std::set<std::string>> txn_resources;
+    std::map<std::string, std::size_t> txn_class_acquires;
+    std::set<std::pair<int, int>> wait_edges;
+
+    for (const operation &op : operations)
+      {
+        const std::string resource_key = make_resource_key (op);
+        std::ostringstream class_key_builder;
+        class_key_builder << op.txn_id << ':' << op.class_oid.volid << ':' << op.class_oid.pageid << ':' << op.class_oid.slotid;
+        const std::string txn_class_key = class_key_builder.str ();
+        std::map<std::string, int>::iterator owner_it = owners.find (resource_key);
+
+        switch (op.kind)
+          {
+          case operation_kind::acquire:
+            stats.acquire_attempts++;
+            if (owner_it == owners.end () || owner_it->second == op.txn_id)
+              {
+                owners[resource_key] = op.txn_id;
+                txn_resources[op.txn_id].insert (resource_key);
+                txn_class_acquires[txn_class_key]++;
+                stats.acquire_grants++;
+                if (txn_class_acquires[txn_class_key] == 10)
+                  {
+                    stats.escalation_candidates++;
+                  }
+              }
+            else
+              {
+                stats.acquire_conflicts++;
+                if (has_path (wait_edges, owner_it->second, op.txn_id))
+                  {
+                    stats.deadlock_pairs++;
+                  }
+                wait_edges.insert (std::make_pair (op.txn_id, owner_it->second));
+              }
+            break;
+
+          case operation_kind::convert:
+            if (owner_it != owners.end () && owner_it->second == op.txn_id)
+              {
+                stats.conversions++;
+              }
+            break;
+
+          case operation_kind::release:
+            if (owner_it != owners.end () && owner_it->second == op.txn_id)
+              {
+                owners.erase (owner_it);
+                txn_resources[op.txn_id].erase (resource_key);
+                stats.releases++;
+              }
+            break;
+          }
+      }
+
+    return stats;
+  }
+} // namespace test_lock_manager

--- a/unit_tests/lock_manager/test_lock_manager_mock_runtime.hpp
+++ b/unit_tests/lock_manager/test_lock_manager_mock_runtime.hpp
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2008 Search Solution Corporation
+ * Copyright 2016 CUBRID Corporation
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+#ifndef _TEST_LOCK_MANAGER_MOCK_RUNTIME_HPP_
+#define _TEST_LOCK_MANAGER_MOCK_RUNTIME_HPP_
+
+#include "test_lock_manager_scenarios.hpp"
+
+#include <cstddef>
+#include <string>
+#include <vector>
+
+namespace test_lock_manager
+{
+  struct simulation_stats
+  {
+    std::size_t acquire_attempts;
+    std::size_t acquire_grants;
+    std::size_t acquire_conflicts;
+    std::size_t conversions;
+    std::size_t releases;
+    std::size_t deadlock_pairs;
+    std::size_t escalation_candidates;
+  };
+
+  class mock_runtime
+  {
+    public:
+      mock_runtime ();
+
+      simulation_stats simulate (const std::vector<operation> &operations);
+
+    private:
+      std::string make_resource_key (const operation &op) const;
+  };
+} // namespace test_lock_manager
+
+#endif // _TEST_LOCK_MANAGER_MOCK_RUNTIME_HPP_

--- a/unit_tests/lock_manager/test_lock_manager_scenarios.cpp
+++ b/unit_tests/lock_manager/test_lock_manager_scenarios.cpp
@@ -1,0 +1,268 @@
+/*
+ * Copyright 2008 Search Solution Corporation
+ * Copyright 2016 CUBRID Corporation
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+#include "test_lock_manager_scenarios.hpp"
+
+#include <algorithm>
+#include <set>
+#include <sstream>
+#include <stdexcept>
+
+namespace test_lock_manager
+{
+  namespace
+  {
+    struct scenario_metadata
+    {
+      scenario_kind kind;
+      const char *name;
+      const char *description;
+    };
+
+    constexpr scenario_metadata SCENARIOS[] = {
+      { scenario_kind::hot_row, "hot_row", "Single-row hotspot contention" },
+      { scenario_kind::hot_class_cold_rows, "hot_class_cold_rows", "Mixed class/instance contention" },
+      { scenario_kind::lock_conversion, "lock_conversion", "Repeated lock conversion workload" },
+      { scenario_kind::deadlock_detector, "deadlock_detector", "Intentional cyclic lock ordering" },
+      { scenario_kind::hash_collision, "hash_collision", "Hash-bucket collision stress" },
+      { scenario_kind::low_contention, "low_contention", "Baseline low-contention throughput" },
+      { scenario_kind::escalation_sweep, "escalation_sweep", "Row-to-class escalation sweep" }
+    };
+
+    mock_oid
+    make_oid (int pageid, int slotid)
+    {
+      mock_oid oid;
+      oid.volid = 1;
+      oid.pageid = pageid;
+      oid.slotid = slotid;
+      return oid;
+    }
+
+    void
+    append_acquire_release (std::vector<operation> &ops, int worker_id, int txn_id, const char *lock_mode,
+                            const mock_oid &class_oid, const mock_oid &oid)
+    {
+      ops.push_back ({ worker_id, txn_id, operation_kind::acquire, lock_mode, class_oid, oid });
+      ops.push_back ({ worker_id, txn_id, operation_kind::release, lock_mode, class_oid, oid });
+    }
+
+    const scenario_metadata &
+    get_metadata (scenario_kind kind)
+    {
+      const scenario_metadata *found = std::find_if (std::begin (SCENARIOS), std::end (SCENARIOS),
+                                                     [kind] (const scenario_metadata &meta)
+      {
+        return meta.kind == kind;
+      });
+
+      if (found == std::end (SCENARIOS))
+        {
+          throw std::invalid_argument ("Unknown scenario kind");
+        }
+      return *found;
+    }
+  } // namespace
+
+  std::vector<std::string>
+  get_scenario_names (void)
+  {
+    std::vector<std::string> names;
+    for (const scenario_metadata &meta : SCENARIOS)
+      {
+        names.emplace_back (meta.name);
+      }
+    return names;
+  }
+
+  std::string
+  get_scenario_description (scenario_kind kind)
+  {
+    return get_metadata (kind).description;
+  }
+
+  scenario_kind
+  parse_scenario_kind (const std::string &name)
+  {
+    auto found = std::find_if (std::begin (SCENARIOS), std::end (SCENARIOS), [&name] (const scenario_metadata &meta)
+    {
+      return name == meta.name;
+    });
+
+    if (found == std::end (SCENARIOS))
+      {
+        throw std::invalid_argument ("Unknown scenario name: " + name);
+      }
+    return found->kind;
+  }
+
+  std::string
+  to_string (scenario_kind kind)
+  {
+    return get_metadata (kind).name;
+  }
+
+  std::string
+  to_string (operation_kind kind)
+  {
+    switch (kind)
+      {
+      case operation_kind::acquire:
+        return "acquire";
+      case operation_kind::convert:
+        return "convert";
+      case operation_kind::release:
+        return "release";
+      }
+
+    return "unknown";
+  }
+
+  std::vector<operation>
+  build_operations (const scenario_config &config)
+  {
+    std::vector<operation> ops;
+    const int effective_hotset = std::max (config.hotset_size, 1);
+
+    if (config.kind == scenario_kind::deadlock_detector)
+      {
+        for (int iter = 0; iter < config.iterations; iter++)
+          {
+            for (int worker = 0; worker < config.worker_count; worker++)
+              {
+                ops.push_back ({ worker, worker, operation_kind::acquire, "X_LOCK", make_oid (110, 0),
+                                 make_oid (400 + worker, 1) });
+              }
+            for (int worker = 0; worker < config.worker_count; worker++)
+              {
+                ops.push_back ({ worker, worker, operation_kind::acquire, "X_LOCK", make_oid (110, 0),
+                                 make_oid (400 + ((worker + 1) % config.worker_count), 1) });
+              }
+            for (int worker = 0; worker < config.worker_count; worker++)
+              {
+                ops.push_back ({ worker, worker, operation_kind::release, "X_LOCK", make_oid (110, 0),
+                                 make_oid (400 + worker, 1) });
+              }
+          }
+
+        return ops;
+      }
+
+    for (int iter = 0; iter < config.iterations; iter++)
+      {
+        for (int worker = 0; worker < config.worker_count; worker++)
+          {
+            const int txn_id = worker;
+            const mock_oid class_oid = make_oid (100 + (worker % effective_hotset), 0);
+
+            switch (config.kind)
+              {
+              case scenario_kind::hot_row:
+                append_acquire_release (ops, worker, txn_id, "X_LOCK", make_oid (100, 0), make_oid (200, 1));
+                break;
+
+              case scenario_kind::hot_class_cold_rows:
+                if (((iter + worker) % 10) == 0)
+                  {
+                    append_acquire_release (ops, worker, txn_id, "X_LOCK", make_oid (100, 0), make_oid (100, 0));
+                  }
+                else
+                  {
+                    append_acquire_release (ops, worker, txn_id, "S_LOCK", make_oid (100, 0),
+                                            make_oid (200 + worker, iter % effective_hotset));
+                  }
+                break;
+
+              case scenario_kind::lock_conversion:
+                ops.push_back ({ worker, txn_id, operation_kind::acquire, "S_LOCK", class_oid,
+                                 make_oid (300 + worker, iter % effective_hotset) });
+                ops.push_back ({ worker, txn_id, operation_kind::convert, "X_LOCK", class_oid,
+                                 make_oid (300 + worker, iter % effective_hotset) });
+                ops.push_back ({ worker, txn_id, operation_kind::release, "X_LOCK", class_oid,
+                                 make_oid (300 + worker, iter % effective_hotset) });
+                break;
+
+              case scenario_kind::hash_collision:
+                append_acquire_release (ops, worker, txn_id, "X_LOCK", make_oid (120, 0),
+                                        make_oid (500 + (iter % effective_hotset) * 1024, worker));
+                break;
+
+              case scenario_kind::low_contention:
+                append_acquire_release (ops, worker, txn_id, "X_LOCK", class_oid,
+                                        make_oid (600 + worker * config.iterations + iter, worker));
+                break;
+
+              case scenario_kind::escalation_sweep:
+                ops.push_back ({ worker, txn_id, operation_kind::acquire, "IX_LOCK", make_oid (130, 0),
+                                 make_oid (130, 0) });
+                append_acquire_release (ops, worker, txn_id, "X_LOCK", make_oid (130, 0),
+                                        make_oid (700 + worker, iter % (effective_hotset * 2)));
+                break;
+              }
+          }
+      }
+
+    return ops;
+  }
+
+  scenario_summary
+  summarize (scenario_kind kind, const std::vector<operation> &operations)
+  {
+    scenario_summary summary;
+    std::set<std::string> distinct_classes;
+    std::set<std::string> distinct_oids;
+
+    summary.name = to_string (kind);
+    summary.description = get_scenario_description (kind);
+    summary.operation_count = operations.size ();
+
+    for (const operation &op : operations)
+      {
+        std::ostringstream class_key;
+        class_key << op.class_oid.volid << ':' << op.class_oid.pageid << ':' << op.class_oid.slotid;
+        distinct_classes.insert (class_key.str ());
+
+        std::ostringstream oid_key;
+        oid_key << op.oid.volid << ':' << op.oid.pageid << ':' << op.oid.slotid;
+        distinct_oids.insert (oid_key.str ());
+
+        summary.operation_kind_counts[to_string (op.kind)]++;
+        summary.lock_mode_counts[op.lock_mode]++;
+      }
+
+    summary.distinct_class_count = distinct_classes.size ();
+    summary.distinct_oid_count = distinct_oids.size ();
+    summary.notes["sample_classes"] = summary.distinct_class_count;
+    summary.notes["sample_oids"] = summary.distinct_oid_count;
+
+    return summary;
+  }
+
+  std::string
+  format_operation (const operation &op)
+  {
+    std::ostringstream out;
+    out << "worker=" << op.worker_id
+        << " txn=" << op.txn_id
+        << " op=" << to_string (op.kind)
+        << " lock=" << op.lock_mode
+        << " class_oid=" << op.class_oid.volid << ':' << op.class_oid.pageid << ':' << op.class_oid.slotid
+        << " oid=" << op.oid.volid << ':' << op.oid.pageid << ':' << op.oid.slotid;
+    return out.str ();
+  }
+} // namespace test_lock_manager

--- a/unit_tests/lock_manager/test_lock_manager_scenarios.hpp
+++ b/unit_tests/lock_manager/test_lock_manager_scenarios.hpp
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2008 Search Solution Corporation
+ * Copyright 2016 CUBRID Corporation
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+#ifndef _TEST_LOCK_MANAGER_SCENARIOS_HPP_
+#define _TEST_LOCK_MANAGER_SCENARIOS_HPP_
+
+#include <cstdint>
+#include <map>
+#include <string>
+#include <vector>
+
+namespace test_lock_manager
+{
+  struct mock_oid
+  {
+    int volid;
+    int pageid;
+    int slotid;
+  };
+
+  enum class scenario_kind
+  {
+    hot_row,
+    hot_class_cold_rows,
+    lock_conversion,
+    deadlock_detector,
+    hash_collision,
+    low_contention,
+    escalation_sweep
+  };
+
+  enum class operation_kind
+  {
+    acquire,
+    convert,
+    release
+  };
+
+  struct operation
+  {
+    int worker_id;
+    int txn_id;
+    operation_kind kind;
+    std::string lock_mode;
+    mock_oid class_oid;
+    mock_oid oid;
+  };
+
+  struct scenario_config
+  {
+    scenario_kind kind;
+    int worker_count;
+    int iterations;
+    int hotset_size;
+    int seed;
+  };
+
+  struct scenario_summary
+  {
+    std::string name;
+    std::string description;
+    std::size_t operation_count;
+    std::size_t distinct_class_count;
+    std::size_t distinct_oid_count;
+    std::map<std::string, std::size_t> operation_kind_counts;
+    std::map<std::string, std::size_t> lock_mode_counts;
+    std::map<std::string, std::size_t> notes;
+  };
+
+  std::vector<std::string> get_scenario_names (void);
+  std::string get_scenario_description (scenario_kind kind);
+  scenario_kind parse_scenario_kind (const std::string &name);
+  std::string to_string (scenario_kind kind);
+  std::string to_string (operation_kind kind);
+
+  std::vector<operation> build_operations (const scenario_config &config);
+  scenario_summary summarize (scenario_kind kind, const std::vector<operation> &operations);
+  std::string format_operation (const operation &op);
+  int run_functional_suite (void);
+  int run_benchmark_suite (int loops);
+} // namespace test_lock_manager
+
+#endif // _TEST_LOCK_MANAGER_SCENARIOS_HPP_

--- a/unit_tests/lock_manager/test_main.cpp
+++ b/unit_tests/lock_manager/test_main.cpp
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2008 Search Solution Corporation
+ * Copyright 2016 CUBRID Corporation
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+#include "test_lock_manager_scenarios.hpp"
+
+#include <cstdlib>
+#include <exception>
+#include <iostream>
+#include <string>
+
+namespace
+{
+  void
+  print_usage (const char *progname)
+  {
+    std::cout << "Usage: " << progname
+              << " [--list] [--functional] [--benchmark] [--scenario <name>]"
+              << " [--workers N] [--iterations N] [--hotset N] [--sample N] [--loops N]" << std::endl;
+  }
+
+  int
+  parse_int (const char *arg_name, const char *value)
+  {
+    char *end_ptr = NULL;
+    long parsed = std::strtol (value, &end_ptr, 10);
+    if (end_ptr == value || *end_ptr != '\0' || parsed <= 0)
+      {
+        throw std::invalid_argument (std::string ("Invalid value for ") + arg_name + ": " + value);
+      }
+    return static_cast<int> (parsed);
+  }
+}
+
+int
+main (int argc, char **argv)
+{
+  try
+    {
+      test_lock_manager::scenario_config config {
+        test_lock_manager::scenario_kind::hot_row,
+        4,
+        10,
+        4,
+        1
+      };
+      int sample_count = 8;
+      int benchmark_loops = 10;
+      bool list_only = false;
+      bool run_functional = false;
+      bool run_benchmark = false;
+
+      for (int index = 1; index < argc; index++)
+        {
+          std::string arg = argv[index];
+          if (arg == "--list")
+            {
+              list_only = true;
+            }
+          else if (arg == "--functional")
+            {
+              run_functional = true;
+            }
+          else if (arg == "--benchmark")
+            {
+              run_benchmark = true;
+            }
+          else if (arg == "--scenario" && index + 1 < argc)
+            {
+              config.kind = test_lock_manager::parse_scenario_kind (argv[++index]);
+            }
+          else if (arg == "--workers" && index + 1 < argc)
+            {
+              config.worker_count = parse_int ("--workers", argv[++index]);
+            }
+          else if (arg == "--iterations" && index + 1 < argc)
+            {
+              config.iterations = parse_int ("--iterations", argv[++index]);
+            }
+          else if (arg == "--hotset" && index + 1 < argc)
+            {
+              config.hotset_size = parse_int ("--hotset", argv[++index]);
+            }
+          else if (arg == "--sample" && index + 1 < argc)
+            {
+              sample_count = parse_int ("--sample", argv[++index]);
+            }
+          else if (arg == "--loops" && index + 1 < argc)
+            {
+              benchmark_loops = parse_int ("--loops", argv[++index]);
+            }
+          else
+            {
+              print_usage (argv[0]);
+              throw std::invalid_argument ("Unknown argument: " + arg);
+            }
+        }
+
+      if (list_only)
+        {
+          std::cout << "Available scenarios:" << std::endl;
+          for (const std::string &name : test_lock_manager::get_scenario_names ())
+            {
+              test_lock_manager::scenario_kind kind = test_lock_manager::parse_scenario_kind (name);
+              std::cout << "  - " << name << ": " << test_lock_manager::get_scenario_description (kind) << std::endl;
+            }
+          return 0;
+        }
+
+      if (run_functional)
+        {
+          return test_lock_manager::run_functional_suite ();
+        }
+
+      if (run_benchmark)
+        {
+          return test_lock_manager::run_benchmark_suite (benchmark_loops);
+        }
+
+      const std::vector<test_lock_manager::operation> operations = test_lock_manager::build_operations (config);
+      const test_lock_manager::scenario_summary summary = test_lock_manager::summarize (config.kind, operations);
+
+      std::cout << "Scenario: " << summary.name << std::endl;
+      std::cout << "Description: " << summary.description << std::endl;
+      std::cout << "Workers: " << config.worker_count << std::endl;
+      std::cout << "Iterations: " << config.iterations << std::endl;
+      std::cout << "Hotset size: " << config.hotset_size << std::endl;
+      std::cout << "Operations: " << summary.operation_count << std::endl;
+      std::cout << "Distinct classes: " << summary.distinct_class_count << std::endl;
+      std::cout << "Distinct OIDs: " << summary.distinct_oid_count << std::endl;
+
+      std::cout << "Operation kind counts:" << std::endl;
+      for (const auto &entry : summary.operation_kind_counts)
+        {
+          std::cout << "  - " << entry.first << ": " << entry.second << std::endl;
+        }
+
+      std::cout << "Lock mode counts:" << std::endl;
+      for (const auto &entry : summary.lock_mode_counts)
+        {
+          std::cout << "  - " << entry.first << ": " << entry.second << std::endl;
+        }
+
+      std::cout << "Sample operations:" << std::endl;
+      for (int idx = 0; idx < sample_count && idx < static_cast<int> (operations.size ()); idx++)
+        {
+          std::cout << "  - " << test_lock_manager::format_operation (operations[idx]) << std::endl;
+        }
+
+      return 0;
+    }
+  catch (const std::exception &e)
+    {
+      std::cerr << "test_lock_manager failed: " << e.what () << std::endl;
+      return 1;
+    }
+}


### PR DESCRIPTION
### Motivation

- Provide a configurable initialization seam for the lock manager so object lock table sizing, freelist partitioning and the deadlock detector can be controlled for tests and benchmarks. 
- Enable isolated, deterministic unit/benchmark testing of the lock manager without booting the full server by adding a small test harness and mock runtime. 

### Description

- Add `LK_INIT_CONFIG` (typedef and struct) and constants such as `LK_INITIAL_OBJECT_LOCK_TABLE_SIZE` and expose `lock_initialize_default_config()` and `lock_initialize_with_config()` to allow external callers to supply / sanitize initialization parameters. 
- Refactor internal init helpers to accept the config: `lock_initialize_object_hash_table(const LK_INIT_CONFIG *)` and `lock_initialize_object_lock_entry_list(const LK_INIT_CONFIG *)`, and add `lock_sanitize_init_config()` and `lock_initialize_default_config_internal()`. 
- Make the deadlock detector startup controllable via the config (`start_deadlock_detector`) and ensure daemon destruction clears the global pointer (`lock_Deadlock_detect_daemon = NULL`). 
- Add a unit test harness under `unit_tests/lock_manager/` including CMake configuration and test binaries (`test_lock_manager`) with scenario generation (`test_lock_manager_scenarios.*`), a mock runtime (`test_lock_manager_mock_runtime.*`), functional tests (`test_lock_manager_functional.cpp`) and a benchmark runner (`test_lock_manager_benchmark.cpp`). 
- Update header exports in `lock_manager.h` to declare the new init functions. 

### Testing

- Built the unit tests with the new option enabled by running CMake with `-DUNIT_TEST_LOCK_MANAGER=ON` and successfully built the `test_lock_manager` target. 
- Ran the isolated functional suite via `test_lock_manager --functional` and the benchmark runner via `test_lock_manager --benchmark`; both executed successfully (return code 0) using the mock runtime simulation. 
- Existing lock manager initialization paths remain supported via the compatibility wrapper `lock_initialize()` which calls `lock_initialize_with_config(NULL)`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bbc89a487083228c3e95cec082013a)